### PR TITLE
fixup: wrong order of item in the same day

### DIFF
--- a/bangumi_report.py
+++ b/bangumi_report.py
@@ -84,7 +84,7 @@ class ImageURLList:
                 star_num = -1
                 if item[4] != '':
                     star_num = int(item[4])
-                self.item_url_list.append({
+                self.item_url_list.insert(0, {
                     'image_url': img_url,
                     'marked_date': marked_time.strftime('%Y-%m-%d'),
                     'title': item[2],
@@ -120,6 +120,7 @@ class ImageURLList:
 
         url_prefix = collect_url + '?page='
         page_list = [url_prefix + str(x) for x in range(1, page_num + 1)]
+        page_list.reverse()
 
         thread_list = []
         for page_url in page_list:


### PR DESCRIPTION
修复由于 bangumi 页面排序为时间倒序，导致生成 report 时同一天的条目也是时间倒序排序的问题。

但是由于多页并行处理，如果有同一天完成的条目分在了不同页面，还是可能出现顺序错误的问题...
去除并行处理应该会有效率问题，翻了 bangumi 条目页面也没有提供用户完成条目的具体时间。
此外 bangumi api 文档页面好像也无法访问了，看了库里源文件好像也没有获取具体时间的 api 接口（或者是需要 appid？）

是否有更好的解决方案？