### PR TITLE
fix(bug): fail to get items using regex

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 jinja2
+lxml


### PR DESCRIPTION
bangumi在最近进行了更新，导致原来基于正则匹配获取信息的脚本无法正常工作了。

因此我将正则匹配部分替换成了更稳定的基于DOM的网页解析（利用XPath），其余地方未做更改。