### PR TITLE
fix: screenshot doesn't work in Firefox

### DIFF
--- a/template.html
+++ b/template.html
@@ -629,7 +629,7 @@
       } else {
         var script = document.createElement('script');
         script.id = 'htmlToImage';
-        script.src = "https://unpkg.com/html-to-image";
+        script.src = "https://unpkg.com/html-to-image@1.11.11/dist/html-to-image.js";
         script.onload = startShot;
         document.body.appendChild(script);
       }


### PR DESCRIPTION
最新版本的 html-to-image 库在处理某些 CSS 属性或外部资源（如 Google Fonts）时，如果获取失败（返回 undefined），再去调用 .trim() 方法就会报错。这会导致截图失败。

目前只在 Firefox 浏览器上发现此问题，估计是因为Firefox 默认开启增强型跟踪保护，该机制会阻断对 Google Fonts 的 CSS 请求。在基于 Chromium 内核的 Edge 浏览器上未发现此问题。

解决方案：将 html-to-image 库回退至 1.11.11，该版本在在处理加载失败的外部 CSS 资源时有空值检查，从而避免 undefined.trim() 导致的直接错误，让截图功能顺利运行。